### PR TITLE
Estatísticas da compressão e botão para salvar arquivo

### DIFF
--- a/src/Compression/Algorithms/Huffman/CompressedFile.cs
+++ b/src/Compression/Algorithms/Huffman/CompressedFile.cs
@@ -1,5 +1,4 @@
 ﻿using Compression.DataStructures;
-using System;
 using System.Collections;
 using System.Collections.Generic;
 
@@ -7,7 +6,6 @@ namespace Compression.Algorithms.Huffman
 {
     public class CompressedFile
     {
-        public static readonly List<string> ImageExtensions = new List<string> { ".JPG", ".JPE", ".BMP", ".GIF", ".PNG" };
         public CompressedFile(byte[] data, int extraBits, Node<byte>[] queue)
         {
             Data = data;
@@ -21,24 +19,7 @@ namespace Compression.Algorithms.Huffman
 
         public Node<byte>[] Queue { get; private set; }
 
-        public string OriginalFileName { get; set; }
-
-        public bool isImage()
-        {
-            String fileExtension = System.IO.Path.GetExtension(OriginalFileName);
-            if (ImageExtensions.Contains(fileExtension.ToUpperInvariant()))
-                return true;
-
-            return false;
-        }
-
-        public bool isHuffman()
-        {
-            if (Queue != null)
-                return true;
-
-            return false;
-        }
+        public string Name { get; set; }
 
         public BitArray BitsTrimmed()
         {

--- a/src/Compression/Algorithms/ICompressor.cs
+++ b/src/Compression/Algorithms/ICompressor.cs
@@ -1,9 +1,4 @@
 ﻿using Compression.Algorithms.Huffman;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Compression.Algorithms
 {
@@ -11,5 +6,7 @@ namespace Compression.Algorithms
     {
         CompressedFile Compress(byte[] file);
         byte[] Decompress(CompressedFile compressedFile);
+
+        decimal Percentage { get; }
     }
 }

--- a/src/Compression/Algorithms/RunLengthEncoding/RunLengthEncodingCompressor.cs
+++ b/src/Compression/Algorithms/RunLengthEncoding/RunLengthEncodingCompressor.cs
@@ -1,24 +1,26 @@
 ﻿using Compression.Algorithms.Huffman;
-using System;
-using System.Collections;
 using System.Collections.Generic;
-using System.Diagnostics;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Compression.Algorithms.RunLengthEncoding
 {
     public class RunLengthEncodingCompressor : ICompressor
     {
-        private const byte MAX_PACKAGE_SIZE = 255; 
+        private const byte MAX_PACKAGE_SIZE = 255;
+
+        private int position;
+
+        private long fileLength;
+
+        public decimal Percentage { get => fileLength > 0 ? (decimal)position / fileLength * 100 : 0; }
+
         public CompressedFile Compress(byte [] file)
         {
+            fileLength = file.LongLength;
             List<byte> newFile = new List<byte>();
 
             byte runValue = file[0];
             byte runCount = 1;
-            for (int position = 1; position < file.Length; position++)
+            for (position = 1; position < file.Length; position++)
             {
                 byte currentByte = file[position];
                 if(runValue == currentByte)

--- a/src/Compression/Compression.csproj
+++ b/src/Compression/Compression.csproj
@@ -52,8 +52,5 @@
     <Compile Include="DataStructures\MinHeap.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
-  <ItemGroup>
-    <None Include="packages.config" />
-  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/src/FileReceiver/FileReceiver.Designer.cs
+++ b/src/FileReceiver/FileReceiver.Designer.cs
@@ -30,6 +30,8 @@
         {
             this.pictureBoxImage = new System.Windows.Forms.PictureBox();
             this.labelStatus = new System.Windows.Forms.Label();
+            this.buttonSalvar = new System.Windows.Forms.Button();
+            this.folderBrowserDialog = new System.Windows.Forms.FolderBrowserDialog();
             ((System.ComponentModel.ISupportInitialize)(this.pictureBoxImage)).BeginInit();
             this.SuspendLayout();
             // 
@@ -39,28 +41,40 @@
             this.pictureBoxImage.Location = new System.Drawing.Point(12, 12);
             this.pictureBoxImage.Name = "pictureBoxImage";
             this.pictureBoxImage.Size = new System.Drawing.Size(311, 215);
-            this.pictureBoxImage.SizeMode = System.Windows.Forms.PictureBoxSizeMode.StretchImage;
+            this.pictureBoxImage.SizeMode = System.Windows.Forms.PictureBoxSizeMode.Zoom;
             this.pictureBoxImage.TabIndex = 0;
             this.pictureBoxImage.TabStop = false;
             // 
             // labelStatus
             // 
             this.labelStatus.AutoSize = true;
-            this.labelStatus.Location = new System.Drawing.Point(12, 241);
+            this.labelStatus.Location = new System.Drawing.Point(12, 265);
             this.labelStatus.Name = "labelStatus";
-            this.labelStatus.Size = new System.Drawing.Size(48, 16);
+            this.labelStatus.Size = new System.Drawing.Size(199, 16);
             this.labelStatus.TabIndex = 1;
-            this.labelStatus.Text = "Status:";
+            this.labelStatus.Text = "Status: Aguardando requisições";
+            // 
+            // buttonSalvar
+            // 
+            this.buttonSalvar.Location = new System.Drawing.Point(12, 233);
+            this.buttonSalvar.Name = "buttonSalvar";
+            this.buttonSalvar.Size = new System.Drawing.Size(311, 25);
+            this.buttonSalvar.TabIndex = 2;
+            this.buttonSalvar.Text = "Salvar arquivo";
+            this.buttonSalvar.UseVisualStyleBackColor = true;
+            this.buttonSalvar.Click += new System.EventHandler(this.buttonSalvar_Click);
             // 
             // FileReceiver
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(8F, 16F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(335, 271);
+            this.ClientSize = new System.Drawing.Size(335, 290);
+            this.Controls.Add(this.buttonSalvar);
             this.Controls.Add(this.labelStatus);
             this.Controls.Add(this.pictureBoxImage);
             this.Font = new System.Drawing.Font("Microsoft Sans Serif", 9.75F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.Margin = new System.Windows.Forms.Padding(4);
+            this.MaximizeBox = false;
             this.Name = "FileReceiver";
             this.Text = "File Receiver";
             this.FormClosing += new System.Windows.Forms.FormClosingEventHandler(this.FileReceiver_FormClosing);
@@ -75,5 +89,7 @@
 
         private System.Windows.Forms.PictureBox pictureBoxImage;
         private System.Windows.Forms.Label labelStatus;
+        private System.Windows.Forms.Button buttonSalvar;
+        private System.Windows.Forms.FolderBrowserDialog folderBrowserDialog;
     }
 }

--- a/src/FileReceiver/FileReceiver.resx
+++ b/src/FileReceiver/FileReceiver.resx
@@ -117,4 +117,7 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <metadata name="folderBrowserDialog.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>150, 17</value>
+  </metadata>
 </root>

--- a/src/FileSender/FileSenderForm.Designer.cs
+++ b/src/FileSender/FileSenderForm.Designer.cs
@@ -36,6 +36,12 @@
             this.comboBoxAlgorithm = new System.Windows.Forms.ComboBox();
             this.buttonSave = new System.Windows.Forms.Button();
             this.buttonSend = new System.Windows.Forms.Button();
+            this.labelStatus = new System.Windows.Forms.Label();
+            this.label2 = new System.Windows.Forms.Label();
+            this.labelTempo = new System.Windows.Forms.Label();
+            this.label3 = new System.Windows.Forms.Label();
+            this.labelTamanho = new System.Windows.Forms.Label();
+            this.folderBrowserDialog = new System.Windows.Forms.FolderBrowserDialog();
             this.panelFile.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.pictureBox)).BeginInit();
             this.SuspendLayout();
@@ -44,12 +50,13 @@
             // 
             this.panelFile.AllowDrop = true;
             this.panelFile.BackColor = System.Drawing.SystemColors.ControlLight;
+            this.panelFile.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Zoom;
             this.panelFile.BorderStyle = System.Windows.Forms.BorderStyle.Fixed3D;
             this.panelFile.Controls.Add(this.pictureBox);
             this.panelFile.Location = new System.Drawing.Point(10, 32);
             this.panelFile.Margin = new System.Windows.Forms.Padding(2);
             this.panelFile.Name = "panelFile";
-            this.panelFile.Size = new System.Drawing.Size(126, 115);
+            this.panelFile.Size = new System.Drawing.Size(144, 115);
             this.panelFile.TabIndex = 0;
             this.panelFile.DragDrop += new System.Windows.Forms.DragEventHandler(this.panelFile_DragDrop);
             this.panelFile.DragEnter += new System.Windows.Forms.DragEventHandler(this.panelFile_DragEnter);
@@ -57,7 +64,7 @@
             // pictureBox
             // 
             this.pictureBox.Image = ((System.Drawing.Image)(resources.GetObject("pictureBox.Image")));
-            this.pictureBox.Location = new System.Drawing.Point(20, 18);
+            this.pictureBox.Location = new System.Drawing.Point(33, 20);
             this.pictureBox.Margin = new System.Windows.Forms.Padding(2);
             this.pictureBox.Name = "pictureBox";
             this.pictureBox.Size = new System.Drawing.Size(80, 71);
@@ -77,11 +84,10 @@
             // 
             // labelCompressionPercent
             // 
-            this.labelCompressionPercent.Anchor = System.Windows.Forms.AnchorStyles.Right;
-            this.labelCompressionPercent.Location = new System.Drawing.Point(84, 151);
+            this.labelCompressionPercent.Location = new System.Drawing.Point(84, 149);
             this.labelCompressionPercent.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.labelCompressionPercent.Name = "labelCompressionPercent";
-            this.labelCompressionPercent.Size = new System.Drawing.Size(49, 17);
+            this.labelCompressionPercent.Size = new System.Drawing.Size(70, 17);
             this.labelCompressionPercent.TabIndex = 3;
             this.labelCompressionPercent.Text = "--%";
             this.labelCompressionPercent.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
@@ -99,15 +105,15 @@
             this.comboBoxAlgorithm.Location = new System.Drawing.Point(10, 7);
             this.comboBoxAlgorithm.Margin = new System.Windows.Forms.Padding(2);
             this.comboBoxAlgorithm.Name = "comboBoxAlgorithm";
-            this.comboBoxAlgorithm.Size = new System.Drawing.Size(126, 21);
+            this.comboBoxAlgorithm.Size = new System.Drawing.Size(144, 21);
             this.comboBoxAlgorithm.TabIndex = 0;
             // 
             // buttonSave
             // 
-            this.buttonSave.Location = new System.Drawing.Point(10, 170);
+            this.buttonSave.Location = new System.Drawing.Point(10, 207);
             this.buttonSave.Margin = new System.Windows.Forms.Padding(2);
             this.buttonSave.Name = "buttonSave";
-            this.buttonSave.Size = new System.Drawing.Size(60, 23);
+            this.buttonSave.Size = new System.Drawing.Size(70, 23);
             this.buttonSave.TabIndex = 4;
             this.buttonSave.Text = "Save";
             this.buttonSave.UseVisualStyleBackColor = true;
@@ -115,14 +121,63 @@
             // 
             // buttonSend
             // 
-            this.buttonSend.Location = new System.Drawing.Point(74, 170);
+            this.buttonSend.Location = new System.Drawing.Point(84, 207);
             this.buttonSend.Margin = new System.Windows.Forms.Padding(2);
             this.buttonSend.Name = "buttonSend";
-            this.buttonSend.Size = new System.Drawing.Size(60, 23);
+            this.buttonSend.Size = new System.Drawing.Size(70, 23);
             this.buttonSend.TabIndex = 5;
             this.buttonSend.Text = "Send";
             this.buttonSend.UseVisualStyleBackColor = true;
             this.buttonSend.Click += new System.EventHandler(this.buttonSend_Click);
+            // 
+            // labelStatus
+            // 
+            this.labelStatus.AutoEllipsis = true;
+            this.labelStatus.Font = new System.Drawing.Font("Microsoft Sans Serif", 6.75F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.labelStatus.Location = new System.Drawing.Point(8, 234);
+            this.labelStatus.Name = "labelStatus";
+            this.labelStatus.Size = new System.Drawing.Size(144, 12);
+            this.labelStatus.TabIndex = 6;
+            this.labelStatus.Text = "Status: -";
+            // 
+            // label2
+            // 
+            this.label2.AutoSize = true;
+            this.label2.Location = new System.Drawing.Point(9, 169);
+            this.label2.Name = "label2";
+            this.label2.Size = new System.Drawing.Size(43, 13);
+            this.label2.TabIndex = 7;
+            this.label2.Text = "Tempo:";
+            // 
+            // labelTempo
+            // 
+            this.labelTempo.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.labelTempo.AutoSize = true;
+            this.labelTempo.Location = new System.Drawing.Point(80, 169);
+            this.labelTempo.Name = "labelTempo";
+            this.labelTempo.Size = new System.Drawing.Size(76, 13);
+            this.labelTempo.TabIndex = 8;
+            this.labelTempo.Text = "00:00:00.0000";
+            // 
+            // label3
+            // 
+            this.label3.AutoSize = true;
+            this.label3.Location = new System.Drawing.Point(9, 187);
+            this.label3.Name = "label3";
+            this.label3.Size = new System.Drawing.Size(55, 13);
+            this.label3.TabIndex = 9;
+            this.label3.Text = "Tamanho:";
+            // 
+            // labelTamanho
+            // 
+            this.labelTamanho.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.labelTamanho.AutoEllipsis = true;
+            this.labelTamanho.Location = new System.Drawing.Point(68, 187);
+            this.labelTamanho.Name = "labelTamanho";
+            this.labelTamanho.Size = new System.Drawing.Size(88, 18);
+            this.labelTamanho.TabIndex = 10;
+            this.labelTamanho.Text = "0 kb";
+            this.labelTamanho.TextAlign = System.Drawing.ContentAlignment.TopRight;
             // 
             // FileSenderForm
             // 
@@ -130,8 +185,13 @@
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
             this.AutoSize = true;
             this.BackColor = System.Drawing.SystemColors.Control;
-            this.ClientSize = new System.Drawing.Size(144, 202);
+            this.ClientSize = new System.Drawing.Size(161, 255);
+            this.Controls.Add(this.labelTamanho);
+            this.Controls.Add(this.label3);
+            this.Controls.Add(this.labelTempo);
+            this.Controls.Add(this.label2);
             this.Controls.Add(this.panelFile);
+            this.Controls.Add(this.labelStatus);
             this.Controls.Add(this.buttonSend);
             this.Controls.Add(this.buttonSave);
             this.Controls.Add(this.comboBoxAlgorithm);
@@ -162,5 +222,11 @@
         private System.Windows.Forms.ComboBox comboBoxAlgorithm;
         private System.Windows.Forms.Button buttonSave;
         private System.Windows.Forms.Button buttonSend;
+        private System.Windows.Forms.Label labelStatus;
+        private System.Windows.Forms.Label label2;
+        private System.Windows.Forms.Label labelTempo;
+        private System.Windows.Forms.Label label3;
+        private System.Windows.Forms.Label labelTamanho;
+        private System.Windows.Forms.FolderBrowserDialog folderBrowserDialog;
     }
 }

--- a/src/FileSender/FileSenderForm.resx
+++ b/src/FileSender/FileSenderForm.resx
@@ -192,4 +192,7 @@
         AElFTkSuQmCC
 </value>
   </data>
+  <metadata name="folderBrowserDialog.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>17, 17</value>
+  </metadata>
 </root>


### PR DESCRIPTION
O cliente traz as estatísticas de compressão (tempo levado, tamanho em porcentagem com relação ao arquivo original e o tamanho em kbytes) e salva o arquivo compactado (com extensão .dat) em um lugar definido pelo usuário.

O servidor consegue identificar se o arquivo é uma imagem ou não, a exibe caso seja, e salva o arquivo descompactado em um lugar definido pelo usuário.

closes #3, closes #6 